### PR TITLE
Add SPAO-D simulation skeleton project

### DIFF
--- a/spaod_sim/README.md
+++ b/spaod_sim/README.md
@@ -1,0 +1,2 @@
+# SPAO-D Simulation (DRM-IC-RWA)
+Skeleton project for LEO laser network simulation under a 1584-satellite Starlink-like constellation.

--- a/spaod_sim/configs/starlink_1584.yaml
+++ b/spaod_sim/configs/starlink_1584.yaml
@@ -1,0 +1,1 @@
+# Placeholder config for 1584-satellite Starlink-like constellation

--- a/spaod_sim/data/ogs.csv
+++ b/spaod_sim/data/ogs.csv
@@ -1,0 +1,1 @@
+# Placeholder for optical ground station data

--- a/spaod_sim/requirements.txt
+++ b/spaod_sim/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+scipy
+pandas
+networkx
+pyyaml
+matplotlib
+tqdm

--- a/spaod_sim/run_spaod.py
+++ b/spaod_sim/run_spaod.py
@@ -1,0 +1,12 @@
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(description="SPAO-D simulation skeleton")
+    parser.add_argument("--config", type=str, default="configs/starlink_1584.yaml")
+    parser.add_argument("--alg", type=str, default="spaod", choices=["spaod","baseline_shortest","baseline_random"])
+    parser.add_argument("--seeds", type=int, default=1)
+    args = parser.parse_args()
+    print("[Skeleton] config=", args.config, " alg=", args.alg, " seeds=", args.seeds)
+
+if __name__ == "__main__":
+    main()

--- a/spaod_sim/spaod/__init__.py
+++ b/spaod_sim/spaod/__init__.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/channel.py
+++ b/spaod_sim/spaod/channel.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/config.py
+++ b/spaod_sim/spaod/config.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/constellation.py
+++ b/spaod_sim/spaod/constellation.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/detector.py
+++ b/spaod_sim/spaod/detector.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/exposure.py
+++ b/spaod_sim/spaod/exposure.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/metrics.py
+++ b/spaod_sim/spaod/metrics.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/plotting.py
+++ b/spaod_sim/spaod/plotting.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/sim.py
+++ b/spaod_sim/spaod/sim.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/solver.py
+++ b/spaod_sim/spaod/solver.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/topology.py
+++ b/spaod_sim/spaod/topology.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.

--- a/spaod_sim/spaod/traffic.py
+++ b/spaod_sim/spaod/traffic.py
@@ -1,0 +1,2 @@
+# Placeholder module for SPAO-D simulation
+# Implementation will be added in subsequent steps.


### PR DESCRIPTION
## Summary
- Add SPAO-D simulation project skeleton with minimal README, requirements and runner script
- Include placeholder modules for simulation components and sample config/data files

## Testing
- `python spaod_sim/run_spaod.py --config configs/starlink_1584.yaml --alg spaod --seeds 3`


------
https://chatgpt.com/codex/tasks/task_e_6895de427b488322b816d40dd7f38716